### PR TITLE
Hotfix/rook and queen movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ At anytime during a game, you can input `RESET` and head back to the startting m
 
 ## Status
 
-Project is at v0.3.1
+Project is at v0.3.2
 
 ## Roadmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fianchetto"
-version = "0.3.1"
+version = "0.3.2"
 description = "A chess game with a CLI"
 authors = [{name = "Agostino Imbimbo Parra", email = "agoimbimboparra@gmail.com"}]
 readme = "README.md"

--- a/src/fianchetto/core/pieces.py
+++ b/src/fianchetto/core/pieces.py
@@ -214,7 +214,7 @@ class Rook(Piece):
                 if (x - dist) >= 0 and game.board[x - dist][y] is not None:
                     check_left = False
                     if game.board[x - dist][y].color != self.color:
-                        moves.append((x + dist, y))
+                        moves.append((x - dist, y))
                 
                 elif (x - dist) >= 0 and game.board[x - dist][y] is None:
                     moves.append((x - dist, y))


### PR DESCRIPTION
Fixed a bug in the rooks generate valid moves function that led to the rook attempting to move off the board